### PR TITLE
Section6

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,9 +40,9 @@
         position: relative;
         padding: 20px 2px 300px 5%;
         height: 4px;
-        width: 500px;
+        width: calc(100%);
         border-style: dotted;
-        border-width: 10px;
+        border-width: calc(100%);
         border-radius: 30px;
         margin: 20px;
 
@@ -102,7 +102,10 @@
   
    
       /* VI. calc() */
-      
+
+    .calc-style {
+        width: calc(100%);
+    }
 
 </style>
       /* IV. Styling text */


### PR DESCRIPTION
VI. calc()
In this section we will perform simple calculations using calc.
1. Try setting `width: 100vw;` on .calc-style class. The element should overflow outside of the screen.
1.1 Set `width: calc(100vw - 100px);` on .calc-style class. Now the element occupies 100px less than the entire width of the screen.
1.3 While in this example we could just use `width: 100%`, Sometimes you will stumble upon scenarios where the `width: 100%` solution does not work due to other CSS properties. calc() is not commonly used and should be avoided. At the same time a lot of CSS frameworks use calc() internally so when we are using CSS frameworks we usually do not need to use calc().
